### PR TITLE
user can view past training programs

### DIFF
--- a/BangazonWorkForce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkForce/Controllers/TrainingProgramController.cs
@@ -67,6 +67,42 @@ namespace BangazonWorkForce.Controllers
             }
         }
 
+        // Get all past training programs
+        public ActionResult IndexPast()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT Id, Name, StartDate, 
+                                            EndDate, MaxAttendees
+	                                        FROM TrainingProgram
+	                                        WHERE StartDate < GETDATE()";
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();
+                    while (reader.Read())
+                    {
+                        TrainingProgram trainingProgram = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                        };
+
+                        trainingPrograms.Add(trainingProgram);
+                    }
+
+                    reader.Close();
+
+                    return View(trainingPrograms);
+                }
+            }
+        }
+
         // Get individual training program details with a list of employees attending the training program
         public ActionResult Details(int id)
         {

--- a/BangazonWorkForce/Views/TrainingProgram/Details.cshtml
+++ b/BangazonWorkForce/Views/TrainingProgram/Details.cshtml
@@ -43,7 +43,6 @@
                 @Html.DisplayFor(model => employee.FullName)
             </dd>
         }
-
     </dl>
 </div>
 <div>

--- a/BangazonWorkForce/Views/TrainingProgram/IndexPast.cshtml
+++ b/BangazonWorkForce/Views/TrainingProgram/IndexPast.cshtml
@@ -1,17 +1,17 @@
 ﻿@model IEnumerable<BangazonWorkForce.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "IndexPast";
 }
 
-<h1>Index</h1>
+<h1>Past Programs</h1>
 
-<p>
-    <a asp-action="Create">Create New</a>
-</p>
 <table class="table">
     <thead>
         <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Id)
+            </th>
             <th>
                 @Html.DisplayNameFor(model => model.Name)
             </th>
@@ -31,6 +31,9 @@
 @foreach (var item in Model) {
         <tr>
             <td>
+                @Html.DisplayFor(modelItem => item.Id)
+            </td>
+            <td>
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
             <td>
@@ -42,15 +45,10 @@
             <td>
                 @Html.DisplayFor(modelItem => item.MaxAttendees)
             </td>
-            <td>
-                @Html.ActionLink("Edit", "Edit", new { id=item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id=item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id=item.Id })
-            </td>
         </tr>
 }
     </tbody>
 </table>
 <p>
-    <a asp-action="IndexPast">View Past Programs</a>
+    <a asp-action="Index">View Upcoming Programs</a>
 </p>

--- a/Readme.md
+++ b/Readme.md
@@ -6,26 +6,32 @@ Bangazon is a virtual marketplace that allows customers to buy and sell products
 ![Image of the Entity Relationship Diagram](/ERD.png)
 
 ## Human Resources
+
 Bangazon Workforce Management enables HR to manage employees, departments and training programs.
 
 ### Employees
+---
 
 ### Departments
-## Author: Jordan Rosas
+---
+###### Author: Jordan Rosas
 - User can view a list of Departments with the name of the department, Number of employees in that department, and the budget
 - User can Create a new department 
 - User can view details of a department and see a list of employees in the details
 
 ### Training Programs
-Author: Brittany Ramos-Janeway
+---
+###### Author: Brittany Ramos-Janeway
 The user has the ability to view all future training programs and create new training programs and assign their start date, end date, and maximum number of attendees. The user can see the details for each training program when they click the "Details" button, and they will be able to see the employees that will be attending the program. The user is able to edit any future training program.
+There is a button on the main Training Programs page that allows users to view a list of past programs.
 
 
 ## IT
 Bangazon Workforce Management enables IT to manage and assign computers.
 
 ### Computers
-## AUTHOR: JORDAN ROSAS
+---
+###### AUTHOR: JORDAN ROSAS
 - IT can create computers
 - IT can Delete computers only if it is not assigned to anyone
 - IT can View Details of the Computers


### PR DESCRIPTION
 
# Description

The app now includes a method to get all past training programs. There is also a view in order to see all past training programs.

Fixes # [Ticket #15](https://github.com/nss-copper-dragonflies/WorkforceManagement/issues/15)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Testing Instructions

1. `git fetch -a`
1. `git checkout brj-past-training-programs`
1. run project
1. click on the `Training Programs` tab
1. click on the `view past projects` button below the list of future projects
1. ensure that the results all have start dates that are before today's date


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added test instructions that prove my fix is effective or that my feature works
